### PR TITLE
feat: Add interpretSpecialCharacters to TypeAsync

### DIFF
--- a/src/Windows-MCP.Net.Test/Desktop/TypeToolTestV2.cs
+++ b/src/Windows-MCP.Net.Test/Desktop/TypeToolTestV2.cs
@@ -1,0 +1,40 @@
+
+using Interface;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Tools.Desktop;
+using WindowsMCP.Net.Services;
+
+namespace Windows_MCP.Net.Test.Desktop
+{
+    public class TypeToolTestV2
+    {
+        private readonly IDesktopService _desktopService;
+        private readonly ILogger<TypeTool> _logger;
+        private readonly TypeTool _typeTool;
+
+        public TypeToolTestV2()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(builder => builder.AddConsole());
+            services.AddSingleton<IDesktopService, DesktopService>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            _desktopService = serviceProvider.GetRequiredService<IDesktopService>();
+            _logger = serviceProvider.GetRequiredService<ILogger<TypeTool>>();
+            _typeTool = new TypeTool(_desktopService, _logger);
+        }
+
+        [Fact]
+        public async Task TypeAsync_WithInterpretSpecialCharacters_ShouldReturnSuccessMessage()
+        {
+            // Act
+            var result = await _typeTool.TypeAsync(100, 200, "Hello\nWorld", false, false, true);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotEmpty(result);
+        }
+    }
+}

--- a/src/Windows-MCP.Net/Interface/IDesktopService.cs
+++ b/src/Windows-MCP.Net/Interface/IDesktopService.cs
@@ -55,8 +55,9 @@ public interface IDesktopService
     /// <param name="text">Text to type</param>
     /// <param name="clear">Whether to clear existing text first</param>
     /// <param name="pressEnter">Whether to press Enter after typing</param>
+    /// <param name="interpretSpecialCharacters">Whether to interpret special characters as key presses</param>
     /// <returns>The result message</returns>
-    Task<string> TypeAsync(int x, int y, string text, bool clear = false, bool pressEnter = false);
+    Task<string> TypeAsync(int x, int y, string text, bool clear = false, bool pressEnter = false, bool interpretSpecialCharacters = false);
 
     /// <summary>
     /// Resize or move an application window.

--- a/src/Windows-MCP.Net/Services/DesktopService.cs
+++ b/src/Windows-MCP.Net/Services/DesktopService.cs
@@ -756,8 +756,9 @@ public class DesktopService : IDesktopService
     /// <param name="text">要输入的文本内容</param>
     /// <param name="clear">是否在输入前清空现有文本</param>
     /// <param name="pressEnter">是否在输入后按回车键</param>
+    /// <param name="interpretSpecialCharacters">Whether to interpret special characters as key presses</param>
     /// <returns>输入操作的结果描述</returns>
-    public async Task<string> TypeAsync(int x, int y, string text, bool clear = false, bool pressEnter = false)
+    public async Task<string> TypeAsync(int x, int y, string text, bool clear = false, bool pressEnter = false, bool interpretSpecialCharacters = false)
     {
         try
         {
@@ -777,7 +778,52 @@ public class DesktopService : IDesktopService
                 await Task.Delay(100);
             }
 
-            SendTextInput(text);
+            if (interpretSpecialCharacters)
+            {
+                var textToSend = new StringBuilder();
+                var processedText = text.Replace("\r\n", "\n");
+
+                foreach (char c in processedText)
+                {
+                    ushort vkCode = 0;
+                    switch (c)
+                    {
+                        case '\n':
+                            vkCode = VK_RETURN;
+                            break;
+                        case '\t':
+                            vkCode = VK_TAB;
+                            break;
+                        case '\b':
+                            vkCode = VK_BACK;
+                            break;
+                    }
+
+                    if (vkCode != 0)
+                    {
+                        if (textToSend.Length > 0)
+                        {
+                            SendTextInput(textToSend.ToString());
+                            textToSend.Clear();
+                        }
+                        SendKeyboardInput(vkCode, true);
+                        SendKeyboardInput(vkCode, false);
+                    }
+                    else
+                    {
+                        textToSend.Append(c);
+                    }
+                }
+
+                if (textToSend.Length > 0)
+                {
+                    SendTextInput(textToSend.ToString());
+                }
+            }
+            else
+            {
+                SendTextInput(text);
+            }
 
             if (pressEnter)
             {

--- a/src/Windows-MCP.Net/Services/DesktopService.cs
+++ b/src/Windows-MCP.Net/Services/DesktopService.cs
@@ -801,8 +801,10 @@ public class DesktopService : IDesktopService
 
                     if (vkCode != 0)
                     {
+                        await Task.Delay(100);
                         if (textToSend.Length > 0)
                         {
+                            // wait for previous text to be sent
                             SendTextInput(textToSend.ToString());
                             textToSend.Clear();
                         }
@@ -817,6 +819,7 @@ public class DesktopService : IDesktopService
 
                 if (textToSend.Length > 0)
                 {
+                    await Task.Delay(100);
                     SendTextInput(textToSend.ToString());
                 }
             }

--- a/src/Windows-MCP.Net/Tools/Desktop/TypeTool.cs
+++ b/src/Windows-MCP.Net/Tools/Desktop/TypeTool.cs
@@ -37,7 +37,7 @@ public class TypeTool
         [Description("Text to type")] string text,
         [Description("Whether to clear existing text first")] bool clear = false,
         [Description("Whether to press Enter after typing")] bool pressEnter = false,
-        [Description("Whether to interpret special characters as key presses")] bool interpretSpecialCharacters = false)
+        [Description("Whether to interpret special characters as key presses (Do not escape special characters in text parameter)")] bool interpretSpecialCharacters = false)
     {
         _logger.LogInformation("Typing text at ({X},{Y}): {Text}", x, y, text);
         

--- a/src/Windows-MCP.Net/Tools/Desktop/TypeTool.cs
+++ b/src/Windows-MCP.Net/Tools/Desktop/TypeTool.cs
@@ -28,6 +28,7 @@ public class TypeTool
     /// <param name="text">Text to type</param>
     /// <param name="clear">Whether to clear existing text first</param>
     /// <param name="pressEnter">Whether to press Enter after typing</param>
+    /// <param name="interpretSpecialCharacters">Whether to interpret special characters as key presses</param>
     /// <returns>Result message</returns>
     [McpServerTool, Description("Type text into input fields, text areas, or focused elements")]
     public async Task<string> TypeAsync(
@@ -35,10 +36,11 @@ public class TypeTool
         [Description("Y coordinate of the target element")] int y,
         [Description("Text to type")] string text,
         [Description("Whether to clear existing text first")] bool clear = false,
-        [Description("Whether to press Enter after typing")] bool pressEnter = false)
+        [Description("Whether to press Enter after typing")] bool pressEnter = false,
+        [Description("Whether to interpret special characters as key presses")] bool interpretSpecialCharacters = false)
     {
         _logger.LogInformation("Typing text at ({X},{Y}): {Text}", x, y, text);
         
-        return await _desktopService.TypeAsync(x, y, text, clear, pressEnter);
+        return await _desktopService.TypeAsync(x, y, text, clear, pressEnter, interpretSpecialCharacters);
     }
 }


### PR DESCRIPTION
This change introduces a new `interpretSpecialCharacters` parameter to the `TypeAsync` method in `IDesktopService.cs` and `DesktopService.cs`. When this parameter is set to `true`, special characters in the input string are interpreted as key presses. For example, `\n` is sent as an `ENTER` key press.